### PR TITLE
Fix metadata syntax in `action.yml` 🛠

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,10 @@
 ---
 name: 'Version Increment'
-description: |
-  Inspects the git tags to determine the current normal version, and returns the
-  next version number.
+description: Inspects the git tags to determine the current normal version, and returns the next version number
 
-  A normal version will be returned if the branch is the default branch
-  (usually `main`), otherwise a pre-release version will be returned.
+branding:
+  icon: plus
+  color: purple
 
 inputs:
   scheme:


### PR DESCRIPTION
Error from GitHub:

```
Description must be less than 125 characters.
```


Not properly documented [here](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#description) in my opinion:
> A short description of the action.

125 characters is short ... but maybe so is 250, or 500, or 1,000.