### PR TITLE
Fix for `env`, fix for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
       - name: Get next version
-        uses: reecetech/version-increment
+        uses: reecetech/version-increment@2021.10.3
         id: version
         with:
           scheme: semver

--- a/action.yml
+++ b/action.yml
@@ -37,5 +37,5 @@ runs:
     - id: version-increment
       run: ${{ github.action_path }}/version-increment.sh
       shell: bash
-      with:
+      env:
         current_version: ${{ steps.version-lookup.outputs.current-version }}


### PR DESCRIPTION
`env` fixup: the syntax was invalid
```
Unexpected value 'with'
```
---
README fixup: the syntax was invalid
```
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```