### PR TITLE
Replace with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
         uses: actions/checkout@v2
 
       - name: Get next version
-        uses: reecetech/version-increment@2021.10.4
+        uses: reecetech/version-increment@2021.11.1
         id: version
         with:
           scheme: semver


### PR DESCRIPTION
2021.10.4 had a bug, we should have updated this when 2021.10.5 came out.  Now the next version will be 2021.11.1