### PR TITLE
Add `v` prefixed version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
         uses: actions/checkout@v2
 
       - name: Get next version
-        uses: reecetech/version-increment@2021.11.1
+        uses: reecetech/version-increment@2021.11.2
         id: version
         with:
           scheme: semver
@@ -82,10 +82,12 @@ Examples:
 
 ### 📤 Outputs
 
-| name            | description                                                        |
-| :---            | :---                                                               |
-| current_version | The current latest version detected from the git repositories tags |
-| version         | The incremented version number (e.g. the next version)             |
+| name              | description                                                                                       |
+| :---              | :---                                                                                              |
+| current-version   | The current latest version detected from the git repositories tags                                |
+| current-v-version | The current latest version detected from the git repositories tags, prefixed with a `v` character |
+| version           | The incremented version number (e.g. the next version)                                            |
+| v-version         | The incremented version number (e.g. the next version), prefixed with a `v` character             |
 
 ## 💕 Contributing
 

--- a/tests/test_version-increment.bats
+++ b/tests/test_version-increment.bats
@@ -104,6 +104,20 @@ function init_repo {
     [[ "$output" = *"::set-output name=version::2.0.0"* ]]
 }
 
+@test "prefixes with v" {
+    init_repo
+
+    export current_version=1.2.3
+    export increment="major"
+
+    run ../../version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 0 ] &&
+    [[ "$output" = *"::set-output name=version::2.0.0"* ]] &&
+    [[ "$output" = *"::set-output name=v-version::v2.0.0"* ]]
+}
+
 @test "increments to a new month (calver)" {
     init_repo
 

--- a/tests/test_version-lookup.bats
+++ b/tests/test_version-lookup.bats
@@ -43,6 +43,19 @@ function init_repo {
     [[ "$output" = *"::set-output name=current-version::0.1.2"* ]]
 }
 
+@test "prefixes with a v" {
+    init_repo
+
+    git tag 0.1.2
+
+    run ../../version-lookup.sh
+
+    print_run_info
+    [ "$status" -eq 0 ] &&
+    [[ "$output" = *"::set-output name=current-version::0.1.2"* ]] &&
+    [[ "$output" = *"::set-output name=current-v-version::v0.1.2"* ]]
+}
+
 @test "finds the current normal version even if there's a newer pre-release version" {
     init_repo
 

--- a/version-increment.sh
+++ b/version-increment.sh
@@ -87,3 +87,4 @@ fi
 echo "ℹ️ The new version is ${new_version}"
 
 echo "::set-output name=version::${new_version}"
+echo "::set-output name=v-version::v${new_version}"

--- a/version-lookup.sh
+++ b/version-lookup.sh
@@ -62,3 +62,4 @@ fi
 echo "ℹ️ The current normal version is ${current_version}"
 
 echo "::set-output name=current-version::${current_version}"
+echo "::set-output name=current-v-version::v${current_version}"


### PR DESCRIPTION
Adds convenience outputs that have a `v` character prefixed to the version number.

Closes #8 