### PR TITLE
Avoid broken pipe exits (`141`) when `head` exits

### DIFF
--- a/version-lookup.sh
+++ b/version-lookup.sh
@@ -34,11 +34,11 @@ fi
 ##  Version parsing
 
 # detect current version - removing "v" from start of tag if it exists
-current_version="$(git tag -l | { ${grep} -P "${pcre_allow_vprefix}" || true; } | sed 's/^v//g' | sort -V --reverse | head -n1)"
+current_version="$(git tag -l | { ${grep} -P "${pcre_allow_vprefix}" || true; } | sed 's/^v//g' | sort -V | tail -n 1)"
 
 # support transition from an old reecetech calver style (yyyy-mm-Rr, where R is the literal `R`, and r is the nth release for the month)
 if [[ -z "${current_version:-}" ]] ; then
-    current_version="$(git tag -l | { ${grep} -P "${pcre_old_calver}" || true; } | sort -V --reverse | head -n1)"
+    current_version="$(git tag -l | { ${grep} -P "${pcre_old_calver}" || true; } | sort -V | tail -n 1)"
     if [[ -n "${current_version:-}" ]] ; then
         # convert - to . and drop leading zeros & the R
         current_version="$(echo "${current_version}" | sed -r 's/^([0-9]+)-0{0,1}([0-9]+)-R0{0,1}([0-9]+)$/\1.\2.\3/')"


### PR DESCRIPTION
Intermittent issue, only observed on self-hosted agents on VMware (due to multi-core processing)

e.g. like this: https://www.ingeniousmalarkey.com/2016/07/git-log-exit-code-141.html