### PR TITLE
Remove deprecated `set-output` calls

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -51,7 +51,7 @@ jobs:
         id: version-increment
         run: ./version-increment.sh
         env:
-          current_version: ${{ steps.version-lookup.outputs.current-version }}
+          current_version: ${{ steps.version-lookup.outputs.CURRENT_VERSION }}
           scheme: calver
 
       - name: Release version
@@ -61,4 +61,4 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: false
           prerelease: false
-          automatic_release_tag: "${{ steps.version-increment.outputs.version }}"
+          automatic_release_tag: "${{ steps.version-increment.outputs.VERSION }}"

--- a/action.yml
+++ b/action.yml
@@ -22,37 +22,37 @@ inputs:
 outputs:
   current-version:
     description: 'Current normal version detected'
-    value: ${{ steps.version-lookup.outputs.current-version }}
+    value: ${{ steps.version-lookup.outputs.CURRENT_VERSION }}
   current-v-version:
     description: 'Current normal version detected, prefixed with a `v` charatcter'
-    value: ${{ steps.version-lookup.outputs.current-v-version }}
+    value: ${{ steps.version-lookup.outputs.CURRENT_V_VERSION }}
   version:
     description: 'Incremented version calculated'
-    value: ${{ steps.version-increment.outputs.version }}
+    value: ${{ steps.version-increment.outputs.VERSION }}
   v-version:
     description: 'Incremented version calculated, prefixed with a `v` charatcter'
-    value: ${{ steps.version-increment.outputs.v-version }}  
+    value: ${{ steps.version-increment.outputs.V_VERSION }}  
   major-version:
     description: 'Major number of the incremented version'
-    value: ${{ steps.version-increment.outputs.major-version }}
+    value: ${{ steps.version-increment.outputs.MAJOR_VERSION }}
   minor-version:
     description: 'Minor number of the incremented version'
-    value: ${{ steps.version-increment.outputs.minor-version }}
+    value: ${{ steps.version-increment.outputs.MINOR_VERSION }}
   patch-version:
     description: 'Patch number of the incremented version'
-    value: ${{ steps.version-increment.outputs.patch-version }}
+    value: ${{ steps.version-increment.outputs.PATCH_VERSION }}
   pre-release-version:
     description: 'Pre-release label of the incremented version'
-    value: ${{ steps.version-increment.outputs.pre-release-label }}
+    value: ${{ steps.version-increment.outputs.PRE_RELEASE_LABEL }}
   major-v-version:
     description: 'Major number of the incremented version, prefixed with a `v` charatcter'
-    value: ${{ steps.version-increment.outputs.major-v-version }}
+    value: ${{ steps.version-increment.outputs.MAJOR_V_VERSION }}
   minor-v-version:
     description: 'Minor number of the incremented version, prefixed with a `v` charatcter'
-    value: ${{ steps.version-increment.outputs.minor-v-version }}
+    value: ${{ steps.version-increment.outputs.MINOR_V_VERSION }}
   patch-v-version:
     description: 'Patch number of the incremented version, prefixed with a `v` charatcter'
-    value: ${{ steps.version-increment.outputs.patch-v-version }}
+    value: ${{ steps.version-increment.outputs.PATCH_V_VERSION }}
 
 runs:
   using: "composite"
@@ -67,6 +67,6 @@ runs:
       run: ${{ github.action_path }}/version-increment.sh
       shell: bash
       env:
-        current_version: ${{ steps.version-lookup.outputs.current-version }}
+        current_version: ${{ steps.version-lookup.outputs.CURRENT_VERSION }}
         increment: ${{ inputs.increment }}
         scheme: ${{ inputs.scheme }}

--- a/shared.sh
+++ b/shared.sh
@@ -32,3 +32,10 @@ if [[ "$(uname)" == "Darwin" ]] ; then
         exit 9
     fi
 fi
+
+##==----------------------------------------------------------------------------
+##  Non GitHub compatibility - for testing both locally and in BATS
+
+if [[ -z "${GITHUB_OUTPUT:-}" || -n "${BATS_VERSION:-}" ]] ; then
+    export GITHUB_OUTPUT="/dev/stdout"
+fi

--- a/tests/test_version-increment.bats
+++ b/tests/test_version-increment.bats
@@ -65,6 +65,13 @@ function init_repo {
     [[ "$output" = *"Value of 'increment' is not valid, choose from 'major', 'minor', or 'patch'"* ]]
 }
 
+@test "no deprecated set-output calls made" {
+    run grep -q "::set-output" version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 1 ]
+}
+
 @test "increments the patch digit correctly (semver)" {
     init_repo
 
@@ -75,10 +82,10 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=major-version::1"* ]] &&
-    [[ "$output" = *"::set-output name=minor-version::2"* ]] &&
-    [[ "$output" = *"::set-output name=patch-version::4"* ]] &&
-    [[ "$output" = *"::set-output name=version::1.2.4"* ]]
+    [[ "$output" = *"MAJOR_VERSION=1"* ]] &&
+    [[ "$output" = *"MINOR_VERSION=2"* ]] &&
+    [[ "$output" = *"PATCH_VERSION=4"* ]] &&
+    [[ "$output" = *"VERSION=1.2.4"* ]]
 }
 
 @test "increments the minor digit correctly (semver)" {
@@ -91,10 +98,10 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=major-version::1"* ]] &&
-    [[ "$output" = *"::set-output name=minor-version::3"* ]] &&
-    [[ "$output" = *"::set-output name=patch-version::0"* ]] &&
-    [[ "$output" = *"::set-output name=version::1.3.0"* ]]
+    [[ "$output" = *"MAJOR_VERSION=1"* ]] &&
+    [[ "$output" = *"MINOR_VERSION=3"* ]] &&
+    [[ "$output" = *"PATCH_VERSION=0"* ]] &&
+    [[ "$output" = *"VERSION=1.3.0"* ]]
 }
 
 @test "increments the major digit correctly (semver)" {
@@ -107,10 +114,10 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=major-version::2"* ]] &&
-    [[ "$output" = *"::set-output name=minor-version::0"* ]] &&
-    [[ "$output" = *"::set-output name=patch-version::0"* ]] &&
-    [[ "$output" = *"::set-output name=version::2.0.0"* ]]
+    [[ "$output" = *"MAJOR_VERSION=2"* ]] &&
+    [[ "$output" = *"MINOR_VERSION=0"* ]] &&
+    [[ "$output" = *"PATCH_VERSION=0"* ]] &&
+    [[ "$output" = *"VERSION=2.0.0"* ]]
 }
 
 @test "prefixes with v" {
@@ -123,11 +130,11 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=version::2.0.0"* ]] &&
-    [[ "$output" = *"::set-output name=major-v-version::v2"* ]] &&
-    [[ "$output" = *"::set-output name=minor-v-version::v0"* ]] &&
-    [[ "$output" = *"::set-output name=patch-v-version::v0"* ]] &&
-    [[ "$output" = *"::set-output name=v-version::v2.0.0"* ]]
+    [[ "$output" = *"VERSION=2.0.0"* ]] &&
+    [[ "$output" = *"MAJOR_V_VERSION=v2"* ]] &&
+    [[ "$output" = *"MINOR_V_VERSION=v0"* ]] &&
+    [[ "$output" = *"PATCH_V_VERSION=v0"* ]] &&
+    [[ "$output" = *"V_VERSION=v2.0.0"* ]]
 }
 
 @test "increments to a new month (calver)" {
@@ -140,7 +147,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=version::$(date +%Y.%-m.1)"* ]]
+    [[ "$output" = *"VERSION=$(date +%Y.%-m.1)"* ]]
 }
 
 @test "increments the patch digit within a month (calver)" {
@@ -153,7 +160,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=version::$(date +%Y.%-m.124)"* ]]
+    [[ "$output" = *"VERSION=$(date +%Y.%-m.124)"* ]]
 }
 
 @test "appends prerelease information if on a branch" {
@@ -167,5 +174,6 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=version::1.2.4-pre.${short_ref}"* ]]
+    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]]
+    [[ "$output" = *"VERSION=1.2.4-pre.${short_ref}"* ]]
 }

--- a/tests/test_version-lookup.bats
+++ b/tests/test_version-lookup.bats
@@ -29,6 +29,13 @@ function init_repo {
     [[ "$output" = *"Value of 'scheme' is not valid"* ]]
 }
 
+@test "no deprecated set-output calls made" {
+    run grep -q "::set-output" version-lookup.sh
+
+    print_run_info
+    [ "$status" -eq 1 ]
+}
+
 @test "finds the current normal version" {
     init_repo
 
@@ -40,7 +47,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::0.1.2"* ]]
+    [[ "$output" = *"CURRENT_VERSION=0.1.2"* ]]
 }
 
 @test "prefixes with a v" {
@@ -52,8 +59,8 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::0.1.2"* ]] &&
-    [[ "$output" = *"::set-output name=current-v-version::v0.1.2"* ]]
+    [[ "$output" = *"CURRENT_VERSION=0.1.2"* ]] &&
+    [[ "$output" = *"CURRENT_V_VERSION=v0.1.2"* ]]
 }
 
 @test "finds the current normal version even if there's a newer pre-release version" {
@@ -66,7 +73,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::1.2.300"* ]]
+    [[ "$output" = *"CURRENT_VERSION=1.2.300"* ]]
 }
 
 @test "returns 0.0.0 if no normal version detected" {
@@ -76,7 +83,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::0.0.0"* ]]
+    [[ "$output" = *"CURRENT_VERSION=0.0.0"* ]]
 }
 
 @test "returns 0.0.0 if no normal version detected even if there's a pre-release version" {
@@ -88,7 +95,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::0.0.0"* ]]
+    [[ "$output" = *"CURRENT_VERSION=0.0.0"* ]]
 }
 
 @test "returns a calver if no normal version detected and calver scheme specified" {
@@ -100,7 +107,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::$(date '+%Y.%-m.0')"* ]]
+    [[ "$output" = *"CURRENT_VERSION=$(date '+%Y.%-m.0')"* ]]
 }
 
 @test "converts from older calver scheme automatically" {
@@ -112,7 +119,7 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::2020.9.2"* ]]
+    [[ "$output" = *"CURRENT_VERSION=2020.9.2"* ]]
 }
 
 @test "strips v from the version" {
@@ -124,5 +131,5 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"::set-output name=current-version::3.4.5"* ]]
+    [[ "$output" = *"CURRENT_VERSION=3.4.5"* ]]
 }

--- a/version-increment.sh
+++ b/version-increment.sh
@@ -76,7 +76,7 @@ fi
 if [[ "${current_ref}" != "refs/heads/${default_branch}" ]] ; then
     pre_release="pre.${git_commit}"
     new_version="${new_version}-${pre_release}"
-    echo "::set-output name=pre-release-label::${pre_release}"
+    echo "PRE_RELEASE_LABEL=${pre_release}" >> "${GITHUB_OUTPUT}"
 fi
 
 if [[ -z "$(echo "${new_version}" | ${grep} -P "${pcre_semver}")" ]] ; then
@@ -88,11 +88,11 @@ fi
 
 echo "ℹ️ The new version is ${new_version}"
 
-echo "::set-output name=version::${new_version}"
-echo "::set-output name=v-version::v${new_version}"
-echo "::set-output name=major-version::${version_array[0]}"
-echo "::set-output name=minor-version::${version_array[1]}"
-echo "::set-output name=patch-version::${version_array[2]}"
-echo "::set-output name=major-v-version::v${version_array[0]}"
-echo "::set-output name=minor-v-version::v${version_array[1]}"
-echo "::set-output name=patch-v-version::v${version_array[2]}"
+echo "VERSION=${new_version}" >> "${GITHUB_OUTPUT}"
+echo "V_VERSION=v${new_version}" >> "${GITHUB_OUTPUT}"
+echo "MAJOR_VERSION=${version_array[0]}" >> "${GITHUB_OUTPUT}"
+echo "MINOR_VERSION=${version_array[1]}" >> "${GITHUB_OUTPUT}"
+echo "PATCH_VERSION=${version_array[2]}" >> "${GITHUB_OUTPUT}"
+echo "MAJOR_V_VERSION=v${version_array[0]}" >> "${GITHUB_OUTPUT}"
+echo "MINOR_V_VERSION=v${version_array[1]}" >> "${GITHUB_OUTPUT}"
+echo "PATCH_V_VERSION=v${version_array[2]}" >> "${GITHUB_OUTPUT}"

--- a/version-increment.sh
+++ b/version-increment.sh
@@ -88,6 +88,7 @@ fi
 
 echo "ℹ️ The new version is ${new_version}"
 
+# shellcheck disable=SC2129
 echo "VERSION=${new_version}" >> "${GITHUB_OUTPUT}"
 echo "V_VERSION=v${new_version}" >> "${GITHUB_OUTPUT}"
 echo "MAJOR_VERSION=${version_array[0]}" >> "${GITHUB_OUTPUT}"

--- a/version-lookup.sh
+++ b/version-lookup.sh
@@ -61,5 +61,5 @@ fi
 
 echo "ℹ️ The current normal version is ${current_version}"
 
-echo "::set-output name=current-version::${current_version}"
-echo "::set-output name=current-v-version::v${current_version}"
+echo "CURRENT_VERSION=${current_version}" >> "${GITHUB_OUTPUT}"
+echo "CURRENT_V_VERSION=v${current_version}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/