### PR TITLE
Add PEP440 compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
         uses: actions/checkout@v2
 
       - name: Get next version
-        uses: reecetech/version-increment@2023.3.1
+        uses: reecetech/version-increment@2023.4.1
         id: version
         with:
           scheme: semver
@@ -24,6 +24,7 @@
 ```
 
 ### 🔖 semver
+
 This action will detect the current latest _normal_ semantic version (semver) from the tags in
 a git repository.  It will increment the version as directed (by default: +1 to
 the patch digit).  Both the current latest and the incremented version are
@@ -52,14 +53,16 @@ e.g. `2021.6.2`
 | minor  | month   | `6`     |
 | patch  | release | `2`     | The *n*th release for the month |
 
-If the current latest normal version is not the current year and month, then the year and month digits will be
+If the current latest normal version is not the current year and month, then the
+year and month digits will be
 set to the current year and month, and the release digit will be reset to 1.
 
 ### 🎋 Default branch vs. any other branch
 
 **Default branch**
 
-The action will return a _normal_ version if it is detected that the current commit is on the default branch (usually `main`).
+The action will return a _normal_ version if it is detected that the current commit
+is on the default branch (usually `main`).
 
 Examples:
 * `1.2.7`
@@ -67,7 +70,10 @@ Examples:
 
 **Any other branch**
 
-The action will return a _pre-release_ version if any other branch is detected (e.g. `new-feature`, `bugfix/foo`, etc).  The _pre-release_ portion of the version number will be the literal string `pre.` followed by the git commit ID short reference SHA (trimmed of any leading zeros).
+The action will return a _pre-release_ version if any other branch is detected
+(e.g. `new-feature`, `bugfix/foo`, etc).  The _pre-release_ portion of the version number
+will be the literal string `pre.` followed by the git commit ID short reference SHA
+(trimmed of any leading zeros).
 
 Examples:
 * `1.2.7-pre.41218aa78`
@@ -78,6 +84,7 @@ Examples:
 | name      | description                                               | required | default  |
 | :---      | :---                                                      | :---     | :---     |
 | scheme    | The versioning scheme in-use, either `semver` or `calver` | No       | `semver` |
+| pep440    | Set to `true` for PEP440 compatibility of _pre-release_ versions by making use of the build metadata segment of semver, which maps to local version identifier in PEP440 | No | `false` |
 | increment | The digit to increment, either `major`, `minor` or `patch`, ignored if `scheme` == `calver` | No | `patch` |
 
 ### 📤 Outputs

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Versioning scheme - semver, or, calver (defaults to semver)'
     required: false
     default: 'semver'
+  pep440:
+    description: 'PEP440 compatibility mode - shifts the pre-release version information into build metadata instead'
+    required: false
+    default: false
   increment:
     description: |
       Field to increment - major, minor, or, patch (defaults to patch)
@@ -69,4 +73,5 @@ runs:
       env:
         current_version: ${{ steps.version-lookup.outputs.CURRENT_VERSION }}
         increment: ${{ inputs.increment }}
+        pep440: ${{ inputs.pep440 }}
         scheme: ${{ inputs.scheme }}

--- a/shared.sh
+++ b/shared.sh
@@ -16,8 +16,14 @@ pcre_old_calver='^(?P<major>0|[1-9]\d*)-0{0,1}(?P<minor>0|[0-9]\d*)-R(?P<patch>0
 
 input_errors='false'
 scheme="${scheme:-semver}"
-if [[ "${scheme}" != 'semver' && "${scheme}" != 'calver' && "${scheme}" != 'pep440' ]] ; then
-    echo "🛑 Value of 'scheme' is not valid, choose from 'semver', 'calver', or 'pep440'" 1>&2
+if [[ "${scheme}" != 'semver' && "${scheme}" != 'calver' ]] ; then
+    echo "🛑 Value of 'scheme' is not valid, choose from 'semver' or 'calver'" 1>&2
+    input_errors='true'
+fi
+
+pep440="${pep440:-false}"
+if [[ "${pep440}" != 'false' && "${pep440}" != 'true' ]] ; then
+    echo "🛑 Value of 'pep440' is not valid, choose from 'false' or 'true'" 1>&2
     input_errors='true'
 fi
 

--- a/shared.sh
+++ b/shared.sh
@@ -16,8 +16,8 @@ pcre_old_calver='^(?P<major>0|[1-9]\d*)-0{0,1}(?P<minor>0|[0-9]\d*)-R(?P<patch>0
 
 input_errors='false'
 scheme="${scheme:-semver}"
-if [[ "${scheme}" != 'semver' && "${scheme}" != 'calver' ]] ; then
-    echo "🛑 Value of 'scheme' is not valid, choose from 'semver' or 'calver'" 1>&2
+if [[ "${scheme}" != 'semver' && "${scheme}" != 'calver' && "${scheme}" != 'pep440' ]] ; then
+    echo "🛑 Value of 'scheme' is not valid, choose from 'semver', 'calver', or 'pep440'" 1>&2
     input_errors='true'
 fi
 

--- a/tests/test_version-increment.bats
+++ b/tests/test_version-increment.bats
@@ -53,6 +53,18 @@ function init_repo {
     [[ "$output" = *"Value of 'scheme' is not valid"* ]]
 }
 
+@test "fails if invalid value for pep440 given" {
+    init_repo
+
+    export pep440="yes"
+
+    run ../../version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 8 ] &&
+    [[ "$output" = *"Value of 'pep440' is not valid"* ]]
+}
+
 @test "fails if invalid increment given" {
     init_repo
 
@@ -104,6 +116,23 @@ function init_repo {
     [[ "$output" = *"VERSION=1.3.0"* ]]
 }
 
+@test "increments the minor digit correctly (explicitly not pep440)" {
+    init_repo
+
+    export current_version=1.2.3
+    export pep404="false"
+    export increment="minor"
+
+    run ../../version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 0 ] &&
+    [[ "$output" = *"MAJOR_VERSION=1"* ]] &&
+    [[ "$output" = *"MINOR_VERSION=3"* ]] &&
+    [[ "$output" = *"PATCH_VERSION=0"* ]] &&
+    [[ "$output" = *"VERSION=1.3.0"* ]]
+}
+
 @test "increments the major digit correctly (semver)" {
     init_repo
 
@@ -120,11 +149,11 @@ function init_repo {
     [[ "$output" = *"VERSION=2.0.0"* ]]
 }
 
-@test "increments the major digit correctly (pep440)" {
+@test "increments the major digit correctly (pep440 mode)" {
     init_repo
 
     export current_version=1.2.3
-    export scheme="pep440"
+    export pep404="true"
     export increment="major"
 
     run ../../version-increment.sh
@@ -199,7 +228,7 @@ function init_repo {
     init_repo
 
     export current_version=10.20.30
-    export scheme="pep440"
+    export pep440="true"
     export GITHUB_REF="refs/heads/super-awesome-python"
     export short_ref="$(git rev-parse --short HEAD | sed 's/0*//')"
 

--- a/tests/test_version-increment.bats
+++ b/tests/test_version-increment.bats
@@ -120,6 +120,23 @@ function init_repo {
     [[ "$output" = *"VERSION=2.0.0"* ]]
 }
 
+@test "increments the major digit correctly (pep440)" {
+    init_repo
+
+    export current_version=1.2.3
+    export scheme="pep440"
+    export increment="major"
+
+    run ../../version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 0 ] &&
+    [[ "$output" = *"MAJOR_VERSION=2"* ]] &&
+    [[ "$output" = *"MINOR_VERSION=0"* ]] &&
+    [[ "$output" = *"PATCH_VERSION=0"* ]] &&
+    [[ "$output" = *"VERSION=2.0.0"* ]]
+}
+
 @test "prefixes with v" {
     init_repo
 
@@ -176,4 +193,20 @@ function init_repo {
     [ "$status" -eq 0 ] &&
     [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]]
     [[ "$output" = *"VERSION=1.2.4-pre.${short_ref}"* ]]
+}
+
+@test "appends prerelease information in pep440 compatible way if on a branch and scheme is pep440" {
+    init_repo
+
+    export current_version=10.20.30
+    export scheme="pep440"
+    export GITHUB_REF="refs/heads/super-awesome-python"
+    export short_ref="$(git rev-parse --short HEAD | sed 's/0*//')"
+
+    run ../../version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 0 ] &&
+    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]]
+    [[ "$output" = *"VERSION=10.20.31+pre.${short_ref}"* ]]
 }

--- a/tests/test_version-increment.bats
+++ b/tests/test_version-increment.bats
@@ -220,11 +220,11 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]]
+    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]] &&
     [[ "$output" = *"VERSION=1.2.4-pre.${short_ref}"* ]]
 }
 
-@test "appends prerelease information in pep440 compatible way if on a branch and scheme is pep440" {
+@test "appends prerelease information in pep440 compatible way when pep440 is true" {
     init_repo
 
     export current_version=10.20.30
@@ -236,6 +236,23 @@ function init_repo {
 
     print_run_info
     [ "$status" -eq 0 ] &&
-    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]]
+    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]] &&
     [[ "$output" = *"VERSION=10.20.31+pre.${short_ref}"* ]]
+}
+
+@test "appends prerelease information in pep440 compatible way when pep440 is true, and using calver scheme" {
+    init_repo
+
+    export current_version=2020.6.4
+    export scheme="calver"
+    export pep440="true"
+    export GITHUB_REF="refs/heads/super-awesome-python"
+    export short_ref="$(git rev-parse --short HEAD | sed 's/0*//')"
+
+    run ../../version-increment.sh
+
+    print_run_info
+    [ "$status" -eq 0 ] &&
+    [[ "$output" = *"PRE_RELEASE_LABEL=pre.${short_ref}"* ]] &&
+    [[ "$output" = *"VERSION=$(date +%Y.%-m.1)+pre.${short_ref}"* ]]
 }

--- a/version-increment.sh
+++ b/version-increment.sh
@@ -75,7 +75,11 @@ fi
 # add pre-release info to version if not the default branch
 if [[ "${current_ref}" != "refs/heads/${default_branch}" ]] ; then
     pre_release="pre.${git_commit}"
-    new_version="${new_version}-${pre_release}"
+    if [[ "${scheme}" == 'pep440' ]] ; then
+        new_version="${new_version}+${pre_release}"
+    else
+        new_version="${new_version}-${pre_release}"
+    fi
     echo "PRE_RELEASE_LABEL=${pre_release}" >> "${GITHUB_OUTPUT}"
 fi
 

--- a/version-increment.sh
+++ b/version-increment.sh
@@ -75,7 +75,7 @@ fi
 # add pre-release info to version if not the default branch
 if [[ "${current_ref}" != "refs/heads/${default_branch}" ]] ; then
     pre_release="pre.${git_commit}"
-    if [[ "${scheme}" == 'pep440' ]] ; then
+    if [[ "${pep440:-}" == 'true' ]] ; then
         new_version="${new_version}+${pre_release}"
     else
         new_version="${new_version}-${pre_release}"

--- a/version-lookup.sh
+++ b/version-lookup.sh
@@ -53,6 +53,9 @@ if [[ -z "${current_version:-}" ]] ; then
         semver)
             current_version="0.0.0"
         ;;
+        pep440)
+            current_version="0.0.0"
+        ;;
         calver)
             current_version="$(date '+%Y.%-m.0')"
         ;;

--- a/version-lookup.sh
+++ b/version-lookup.sh
@@ -53,9 +53,6 @@ if [[ -z "${current_version:-}" ]] ; then
         semver)
             current_version="0.0.0"
         ;;
-        pep440)
-            current_version="0.0.0"
-        ;;
         calver)
             current_version="$(date '+%Y.%-m.0')"
         ;;


### PR DESCRIPTION
This compatibility mode makes non-default branch version increments place the [pre-release information](https://semver.org/spec/v2.0.0.html#spec-item-9) in a semver [build metadata](https://semver.org/spec/v2.0.0.html#spec-item-10) segment.  This is compatible with PEP440, where the semver build metadata is treated as a [local version identifier](https://peps.python.org/pep-0440/#local-version-identifiers).

Alternatively we could have converted the git short-ref from hex to decimal, but I felt this would be less obvious / useful since it would on the consumers of the versioning to convert back from decimal to hex to find the git commit.