### PR TITLE
Update shellcheck action

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9  # v1.1.0
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           check_together: 'yes'
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
         uses: actions/checkout@v2
 
       - name: Get next version
-        uses: reecetech/version-increment@2023.4.1
+        uses: reecetech/version-increment@2023.9.3
         id: version
         with:
           scheme: semver


### PR DESCRIPTION
Solves for `set-output` deprecation warnings