### PR TITLE
Add new `use_api` feature, to allow the action to work without checking out the repo first

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -34,15 +34,15 @@ jobs:
       - name: Test
         run: bats tests/*.bats
 
-  test-api:
+  test-api-mode:  # requires github API, didn't want to mock it
     runs-on: ubuntu-latest
     env:
       github_token: ${{ github.token }}
     steps:
-      - name: Checkout code
+      - name: Checkout code  # have to checkout to have the source code available
         uses: actions/checkout@v4
 
-      - name: Remove .git directory
+      - name: Remove .git directory  # remove the git directory to make the testing valid
         run: rm -rf .git/
 
       - name: Test lookup version (with API)
@@ -67,11 +67,48 @@ jobs:
         shell: bash
         run: '[[ "$(date +%Y.%m)" == "$(echo "${{ steps.version-increment.outputs.VERSION }}" | cut -d "." -f 1-2)" ]]'
 
-  release:
+  test-action-yml:  # integration testing
     needs:
       - lint
       - test
-      - test-api
+      - test-api-mode
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code  # have to checkout to have the source code available
+        uses: actions/checkout@v4
+
+      - name: Remove .git directory  # remove the git directory to make the testing valid
+        run: rm -rf .git/
+
+      - name: Get next version via API
+        uses: ./
+        id: version-via-api
+        with:
+          scheme: 'calver'
+          use_api: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get next version via Git
+        uses: ./
+        id: version-via-git
+        with:
+          scheme: 'calver'
+          use_api: false
+
+      - name: Check results agree
+        shell: bash
+        run: |
+          [[ "${{ steps.version-via-api.outputs.current-version }}" == "${{ steps.version-via-git.outputs.current-version }}" ]]
+          [[ "${{ steps.version-via-api.outputs.major-version }}" == "${{ steps.version-via-git.outputs.major-version }}" ]]
+          [[ "${{ steps.version-via-api.outputs.minor-version }}" == "${{ steps.version-via-git.outputs.minor-version }}" ]]
+          [[ "${{ steps.version-via-api.outputs.patch-version }}" == "${{ steps.version-via-git.outputs.patch-version }}" ]]
+          # Don't test the full version or pre-version, since the number of digits is likely to be different (9 via api vs. 7 via git)
+
+  release:
+    needs:
+      - test-action-yml
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup bats
         uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d  # v1.2.0
@@ -34,14 +34,48 @@ jobs:
       - name: Test
         run: bats tests/*.bats
 
+  test-api:
+    runs-on: ubuntu-latest
+    env:
+      github_token: ${{ github.token }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Remove .git directory
+        run: rm -rf .git/
+
+      - name: Test lookup version (with API)
+        id: version-lookup
+        env:
+          use_api: 'true'
+        run: ./version-lookup.sh
+
+      - name: Check lookup result
+        shell: bash
+        run: '[[ -n "${{ steps.version-lookup.outputs.CURRENT_VERSION }}" ]]'
+
+      - name: Test increment version (with API)
+        id: version-increment
+        run: ./version-increment.sh
+        env:
+          current_version: ${{ steps.version-lookup.outputs.CURRENT_VERSION }}
+          scheme: calver
+          use_api: 'true'
+
+      - name: Check increment result
+        shell: bash
+        run: '[[ "$(date +%Y.%m)" == "$(echo "${{ steps.version-increment.outputs.VERSION }}" | cut -d "." -f 1-2)" ]]'
+
   release:
     needs:
       - lint
       - test
+      - test-api
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lookup version
         id: version-lookup

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# ➕ Version Increment
+# Version Increment ➕
 
-## 📄 Use
+## Use 📄
 
-### ⌨️ Example
+### Example ⌨️
 
 ```yaml
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get next version
         uses: reecetech/version-increment@2023.9.3
@@ -23,7 +23,20 @@
           context: .
 ```
 
-### 🔖 semver
+#### API mode 🔗
+
+Maybe you don't want to checkout your code in the job that calculates the version number.  That's okay, you can
+use the API mode:
+
+```yaml
+      - name: Get next version
+        uses: reecetech/version-increment@2023.10.1
+        id: version
+        with:
+          use_api: true
+```
+
+### semver 🔖
 
 This action will detect the current latest _normal_ semantic version (semver) from the tags in
 a git repository.  It will increment the version as directed (by default: +1 to
@@ -37,7 +50,7 @@ e.g. `1.2.7`
 
 See: https://semver.org/spec/v2.0.0.html
 
-### 📅 calver (semver compliant)
+### calver (semver compliant) 📅
 
 Optionally, this action can provide semver compliant calendar versions (calver).
 In this calver scheme, the semver  major, minor and patch digits map to year,
@@ -57,7 +70,7 @@ If the current latest normal version is not the current year and month, then the
 year and month digits will be
 set to the current year and month, and the release digit will be reset to 1.
 
-### 🎋 Default branch vs. any other branch
+### Default branch vs. any other branch 🎋
 
 **Default branch**
 
@@ -67,6 +80,17 @@ is on the default branch (usually `main`).
 Examples:
 * `1.2.7`
 * `2021.6.2`
+
+You may override the branch to consider the release branch if it is not the default branch, by providing a specific
+release branch name as an input.  For example:
+
+```yaml
+      - name: Get next version
+        uses: reecetech/version-increment@2023.10.1
+        id: version
+        with:
+          release_branch: publish
+```
 
 **Any other branch**
 
@@ -79,7 +103,7 @@ Examples:
 * `1.2.7-pre.41218aa78`
 * `2021.6.2-pre.32fd19841`
 
-### 📥 Inputs
+### Inputs 📥
 
 | name           | description                                                                                 | required | default  |
 | :---           | :---                                                                                        | :---     | :---     |
@@ -87,8 +111,9 @@ Examples:
 | pep440         | Set to `true` for PEP440 compatibility of _pre-release_ versions by making use of the build metadata segment of semver, which maps to local version identifier in PEP440 | No       | `false`  |
 | increment      | The digit to increment, either `major`, `minor` or `patch`, ignored if `scheme` == `calver` | No       | `patch`  |
 | release_branch | Specify a non-default branch to use for the release tag (the one without -pre)              | No       |          |
+| use_api        | Use the GitHub API to discover current tags, which avoids the need for a git checkout, but requires `curl` and `jq` | No       | `false`  |
 
-### 📤 Outputs
+### Outputs 📤
 
 | name              | description                                                                                       |
 | :---              | :---                                                                                              |
@@ -104,7 +129,7 @@ Examples:
 | minor-v-version   | Minor number of the incremented version, prefixed with a `v` character                            |
 | patch-v-version   | Patch number of the incremented version, prefixed with a `v` character                            |
 
-## 💕 Contributing
+## Contributing 💕
 
 Please raise a pull request, but note the testing tools below
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Specify a non-default branch to use for the release tag (the one without -pre)'
     required: false
     type: string
+  use_api:
+    description: 'Use the GitHub API to discover current tags, which avoids the need for a git checkout, but requires `curl` and `jq`'
+    required: false
+    default: false
 
 outputs:
   current-version:
@@ -69,7 +73,9 @@ runs:
       run: ${{ github.action_path }}/version-lookup.sh
       shell: bash
       env:
+        github_token: ${{ github.token }}
         scheme: ${{ inputs.scheme }}
+        use_api: ${{ inputs.use_api }}
 
     - id: version-increment
       run: ${{ github.action_path }}/version-increment.sh
@@ -77,6 +83,8 @@ runs:
       env:
         current_version: ${{ steps.version-lookup.outputs.CURRENT_VERSION }}
         increment: ${{ inputs.increment }}
+        github_token: ${{ github.token }}
         pep440: ${{ inputs.pep440 }}
         scheme: ${{ inputs.scheme }}
         release_branch: ${{ inputs.release_branch }}
+        use_api: ${{ inputs.use_api }}

--- a/shared.sh
+++ b/shared.sh
@@ -27,6 +27,20 @@ if [[ "${pep440}" != 'false' && "${pep440}" != 'true' ]] ; then
     input_errors='true'
 fi
 
+use_api="${use_api:-false}"
+if [[ "${use_api}" != 'false' && "${use_api}" != 'true' ]] ; then
+    echo "🛑 Value of 'use_api' is not valid, choose from 'false' or 'true'" 1>&2
+    input_errors='true'
+fi
+
+if [[ "${use_api}" == 'true' ]] ; then
+    if [[ -z "${github_token:-}" ]] ; then
+        echo "🛑 'use_api' is true, but environment variable 'github_token' is not set" 1>&2
+        input_errors='true'
+    fi
+fi
+
+
 ##==----------------------------------------------------------------------------
 ##  MacOS compatibility - for local testing
 


### PR DESCRIPTION
I got thinking there might be cases where it would be better to not have to checkout a repo - particularly if it was a large repo